### PR TITLE
Make Coyoneda map stack safe

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -367,6 +367,9 @@
 		B568E5EC2529DCC200AD334B /* Exists.swift in Sources */ = {isa = PBXBuildFile; fileRef = B52120FE2523AC2300705BCD /* Exists.swift */; };
 		B568E6032529DCD200AD334B /* ExistsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55F52B125247256001979EE /* ExistsTests.swift */; };
 		B56A08632525C39600869FCD /* CokleisliK.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56A08622525C39600869FCD /* CokleisliK.swift */; };
+		B5BF5086252B0F4A0060AD0D /* Function1LazyComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF5085252B0F4A0060AD0D /* Function1LazyComposition.swift */; };
+		B5BF50F7252B24AF0060AD0D /* Function1LazyCompositionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF509D252B23D30060AD0D /* Function1LazyCompositionTest.swift */; };
+		B5BF510F252B253D0060AD0D /* Function1LazyComposition+Gen.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BF510E252B253D0060AD0D /* Function1LazyComposition+Gen.swift */; };
 		B8B910C0234D7F2600E44271 /* Semiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910BF234D7F2600E44271 /* Semiring.swift */; };
 		B8B910C4234D846900E44271 /* SemiringLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C3234D846900E44271 /* SemiringLaws.swift */; };
 		B8B910C6234DDA4000E44271 /* BoolInstancesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */; };
@@ -1241,6 +1244,9 @@
 		B55F52B125247256001979EE /* ExistsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistsTests.swift; sourceTree = "<group>"; };
 		B568E5BE2529D1A200AD334B /* FunctionK+Coyoneda.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FunctionK+Coyoneda.swift"; sourceTree = "<group>"; };
 		B56A08622525C39600869FCD /* CokleisliK.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CokleisliK.swift; sourceTree = "<group>"; };
+		B5BF5085252B0F4A0060AD0D /* Function1LazyComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Function1LazyComposition.swift; sourceTree = "<group>"; };
+		B5BF509D252B23D30060AD0D /* Function1LazyCompositionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Function1LazyCompositionTest.swift; sourceTree = "<group>"; };
+		B5BF510E252B253D0060AD0D /* Function1LazyComposition+Gen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Function1LazyComposition+Gen.swift"; sourceTree = "<group>"; };
 		B8B910BF234D7F2600E44271 /* Semiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Semiring.swift; sourceTree = "<group>"; };
 		B8B910C3234D846900E44271 /* SemiringLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemiringLaws.swift; sourceTree = "<group>"; };
 		B8B910C5234DDA4000E44271 /* BoolInstancesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolInstancesTest.swift; sourceTree = "<group>"; };
@@ -1465,6 +1471,7 @@
 			children = (
 				112097C422A805CE007F3D9C /* Function0+Gen.swift */,
 				112097C622A80730007F3D9C /* Function1+Gen.swift */,
+				B5BF510E252B253D0060AD0D /* Function1LazyComposition+Gen.swift */,
 				112097D722A90644007F3D9C /* Kleisli+Gen.swift */,
 			);
 			path = Arrow;
@@ -1902,6 +1909,7 @@
 				8BA0F390217E2DEF00969984 /* Function0Test.swift */,
 				8BA0F38F217E2DEF00969984 /* Function1Test.swift */,
 				8BA0F391217E2DEF00969984 /* KleisliTest.swift */,
+				B5BF509D252B23D30060AD0D /* Function1LazyCompositionTest.swift */,
 			);
 			path = Arrow;
 			sourceTree = "<group>";
@@ -1982,6 +1990,7 @@
 				8BA0F448217E2E9200969984 /* Cokleisli.swift */,
 				8BA0F445217E2E9200969984 /* Function0.swift */,
 				8BA0F446217E2E9200969984 /* Function1.swift */,
+				B5BF5085252B0F4A0060AD0D /* Function1LazyComposition.swift */,
 				8BA0F443217E2E9200969984 /* FunctionK.swift */,
 				8BA0F444217E2E9200969984 /* Kleisli.swift */,
 				B56A08622525C39600869FCD /* CokleisliK.swift */,
@@ -2869,6 +2878,7 @@
 				112097E122A90AAA007F3D9C /* WriterT+Gen.swift in Sources */,
 				112097C122A7FF37007F3D9C /* Validated+Gen.swift in Sources */,
 				112097B922A7FAF6007F3D9C /* Ior+Gen.swift in Sources */,
+				B5BF510F252B253D0060AD0D /* Function1LazyComposition+Gen.swift in Sources */,
 				112097CE22A81BE8007F3D9C /* EitherK+Gen.swift in Sources */,
 				112097BD22A7FD6F007F3D9C /* Option+Gen.swift in Sources */,
 				112097DD22A90899007F3D9C /* OptionT+Gen.swift in Sources */,
@@ -3213,6 +3223,7 @@
 			files = (
 				8BA0F409217E2DEF00969984 /* TryTest.swift in Sources */,
 				8BA0F406217E2DEF00969984 /* StoreTTest.swift in Sources */,
+				B5BF50F7252B24AF0060AD0D /* Function1LazyCompositionTest.swift in Sources */,
 				8BA0F3E9217E2DEF00969984 /* PartialApplicationTest.swift in Sources */,
 				1171ED5723C4E614005362E0 /* TracedTTest.swift in Sources */,
 				8BA0F3F3217E2DEF00969984 /* OptionTTest.swift in Sources */,
@@ -3341,6 +3352,7 @@
 				8BA0F607217E2E9200969984 /* MonadError.swift in Sources */,
 				11E5F3D3242BB16C005CF07A /* Ior.swift in Sources */,
 				11A5FDD022E5C79F00FF7821 /* BindingOperator.swift in Sources */,
+				B5BF5086252B0F4A0060AD0D /* Function1LazyComposition.swift in Sources */,
 				8BA0F597217E2E9200969984 /* EitherK.swift in Sources */,
 				1171ED4D23C4CB7C005362E0 /* TracedT.swift in Sources */,
 				1125054D220DD92B00861131 /* EquatableK.swift in Sources */,

--- a/Sources/Bow/Arrow/Function1.swift
+++ b/Sources/Bow/Arrow/Function1.swift
@@ -35,7 +35,7 @@ public final class Function1<I, O>: Function1Of<I, O> {
     public func invoke(_ value: I) -> O {
         f(value)
     }
-    
+
     /// Invokes this function.
     ///
     /// - Parameter value: Input to the function.

--- a/Sources/Bow/Arrow/Function1LazyComposition.swift
+++ b/Sources/Bow/Arrow/Function1LazyComposition.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public final class ForFunction1LazyComposition {}
+public final class Function1LazyCompositionPartial<I>: Kind<ForFunction1LazyComposition, I> {}
+public typealias Function1LazyCompositionOf<I, O> = Kind<Function1LazyCompositionPartial<I>, O>
+public final class Function1LazyComposition<I, O>: Function1LazyCompositionOf<I, O> {
+    public init(_ f: @escaping (I) -> O) {
+        functions = [erase(f)]
+    }
+
+    init(_ functions: [(Any) -> Any]) {
+        self.functions = functions
+    }
+
+    let functions: [(Any) -> Any]
+
+    public static func fix(_ fa: Function1LazyCompositionOf<I, O>) -> Function1LazyComposition<I, O> {
+        fa as! Function1LazyComposition<I, O>
+    }
+
+    public var run: (I) -> O {
+        { (i: I) in
+            self.functions.foldLeft(i) { (x, f) in
+                f(x)
+            } as! O
+        }
+    }
+
+    public func compose<A>(_ f: Function1LazyComposition<A, I>) -> Function1LazyComposition<A, O> {
+        Function1LazyComposition<A, O>(f.functions + functions)
+    }
+
+    public func andThen<A>(_ f: Function1LazyComposition<O, A>) -> Function1LazyComposition<I, A> {
+        f.compose(self)
+    }
+
+    public func contramap<A>(_ f: @escaping (A) -> I) -> Function1LazyComposition<A, O> {
+        compose(Function1LazyComposition<A, I>(f))
+    }
+}
+
+fileprivate func erase<I, O>(_ f: @escaping (I) -> O) -> (Any) -> Any {
+    { f($0 as! I) }
+}
+
+public postfix func ^<I, O>(_ fa: Function1LazyCompositionOf<I, O>) -> Function1LazyComposition<I, O> {
+    Function1LazyComposition.fix(fa)
+}
+
+// MARK: Instance of Functor for Function1LazyComposition
+extension Function1LazyCompositionPartial: Functor {
+    public static func map<A, B>(
+        _ fa: Function1LazyCompositionOf<I, A>,
+        _ f: @escaping (A) -> B) -> Function1LazyCompositionOf<I, B> {
+        fa^.andThen(Function1LazyComposition(f))
+    }
+}

--- a/Sources/BowFree/Coyoneda.swift
+++ b/Sources/BowFree/Coyoneda.swift
@@ -7,11 +7,16 @@ internal typealias CoyonedaFOf<F, A, P> = Kind<CoyonedaFPartial<F, A>, P>
 internal final class CoyonedaF<F, A, P>: CoyonedaFOf<F, A, P> {
     init(pivot: Kind<F, P>, f: @escaping (P) -> A) {
         self.pivot = pivot
+        self.f = Function1LazyComposition(f)
+    }
+
+    init(pivot: Kind<F, P>, f: Function1LazyComposition<P, A>) {
+        self.pivot = pivot
         self.f = f
     }
 
     let pivot: Kind<F, P>
-    let f: (P) -> A
+    let f: Function1LazyComposition<P, A>
 
     static func fix(_ fa: CoyonedaFOf<F, A, P>) -> CoyonedaF<F, A, P> {
         fa as! CoyonedaF<F, A, P>
@@ -85,7 +90,7 @@ extension Coyoneda where F: Functor {
 
     private class Lower<F: Functor, A>: CokleisliK<CoyonedaFPartial<F, A>, Kind<F, A>> {
         public override func invoke<T>(_ fa: CoyonedaFOf<F, A, T>) -> Kind<F, A> {
-            fa^.pivot.map(fa^.f)
+            fa^.pivot.map(fa^.f.run)
         }
     }
 }
@@ -116,7 +121,7 @@ extension CoyonedaPartial: Functor {
         let f: (A) -> B
 
         override func invoke<T>(_ fa: CoyonedaFOf<F, A, T>) -> CoyonedaOf<F, B> {
-            Coyoneda(pivot: fa^.pivot, f: f <<< fa^.f)
+            Coyoneda(pivot: fa^.pivot, f: f <<< fa^.f.run)
         }
     }
 }
@@ -161,7 +166,7 @@ extension CoyonedaPartial: Monad where F: Monad {
 
         override func invoke<T>(_ fa: Kind<CoyonedaFPartial<F, A>, T>) -> CoyonedaOf<F, B> {
             Coyoneda.liftCoyoneda(
-                F.flatMap(fa^.pivot) { (self.f <<< fa^.f)($0)^.lower() }
+                F.flatMap(fa^.pivot) { (self.f <<< fa^.f.run)($0)^.lower() }
             )
         }
     }
@@ -198,7 +203,7 @@ extension CoyonedaPartial: Comonad where F: Comonad {
 
         override func invoke<T>(_ fa: Kind<CoyonedaFPartial<F, A>, T>) -> CoyonedaOf<F, B> {
             Coyoneda.liftCoyoneda(
-                fa^.pivot.coflatMap { self.f(Coyoneda(pivot: $0, f: fa^.f)) }
+                fa^.pivot.coflatMap { self.f(Coyoneda(pivot: $0, f: fa^.f.run)) }
             )
         }
     }
@@ -213,7 +218,7 @@ extension CoyonedaPartial: Comonad where F: Comonad {
         internal override init() {}
 
         override func invoke<T>(_ fa: Kind<CoyonedaFPartial<F, A>, T>) -> A {
-            fa^.f(fa^.pivot.extract())
+            fa^.f.run(fa^.pivot.extract())
         }
     }
 }
@@ -240,7 +245,7 @@ extension CoyonedaPartial: Foldable where F: Foldable {
 
         override func invoke<T>(_ fa: Kind<CoyonedaFPartial<F, A>, T>) -> B {
             fa^.pivot.foldLeft(b) { b, t in
-                self.f(b, fa^.f(t))
+                self.f(b, fa^.f.run(t))
             }
         }
     }
@@ -264,7 +269,7 @@ extension CoyonedaPartial: Foldable where F: Foldable {
 
         override func invoke<T>(_ fa: Kind<CoyonedaFPartial<F, A>, T>) -> Eval<B> {
             fa^.pivot.foldRight(b) { t, b in
-                self.f(fa^.f(t), b)
+                self.f(fa^.f.run(t), b)
             }
         }
     }
@@ -288,7 +293,7 @@ extension CoyonedaPartial: Traverse where F: Traverse {
         let f: (A) -> Kind<G, B>
 
         override func invoke<T>(_ fa: Kind<CoyonedaFPartial<F, A>, T>) -> Kind<G, CoyonedaOf<F, B>> {
-            fa^.pivot.traverse(f <<< fa^.f)
+            fa^.pivot.traverse(f <<< fa^.f.run)
                 .map(Coyoneda.liftCoyoneda)
         }
     }

--- a/Tests/BowGenerators/Arrow/Function1LazyComposition+Gen.swift
+++ b/Tests/BowGenerators/Arrow/Function1LazyComposition+Gen.swift
@@ -1,0 +1,20 @@
+import Bow
+import SwiftCheck
+
+// MARK: Generator for Property-based Testing
+
+extension Function1LazyComposition: Arbitrary where I: CoArbitrary & Hashable, O: Arbitrary {
+    public static var arbitrary: Gen<Function1LazyComposition<I, O>> {
+        ArrowOf<I, O>.arbitrary.map { arrow in
+            Function1LazyComposition(arrow.getArrow)
+        }
+    }
+}
+
+// MARK: Instance of ArbitraryK for Function1
+
+extension Function1LazyCompositionPartial: ArbitraryK where I: CoArbitrary & Hashable {
+    public static func generate<A: Arbitrary>() -> Function1LazyCompositionOf<I, A> {
+        Function1LazyComposition.arbitrary.generate
+    }
+}

--- a/Tests/BowTests/Arrow/Function1LazyCompositionTest.swift
+++ b/Tests/BowTests/Arrow/Function1LazyCompositionTest.swift
@@ -1,0 +1,40 @@
+import XCTest
+import SwiftCheck
+@testable import BowLaws
+import Bow
+
+extension Function1LazyCompositionPartial: EquatableK where I == Int {
+    public static func eq<A>(_ lhs: Kind<Function1LazyCompositionPartial<I>, A>, _ rhs: Kind<Function1LazyCompositionPartial<I>, A>) -> Bool where A : Equatable {
+        Function1LazyComposition.fix(lhs).run(1)
+            ==
+        Function1LazyComposition.fix(rhs).run(1)
+    }
+}
+
+extension Function1LazyComposition: Semigroup where I == O {
+    public func combine(_ other: Function1LazyComposition) -> Function1LazyComposition {
+        andThen(other)
+    }
+}
+
+class Function1LazyCompositionTest: XCTestCase {
+    func testFunctorLaws() {
+        FunctorLaws<Function1LazyCompositionPartial<Int>>.check()
+    }
+
+    func testEquivalenceToFunction1() {
+        property("Function1LazyComposition gives the same result than Function1") <~ forAll() { (i: Int, f: ArrowOf<Int, String>, g: ArrowOf<String, Int>) in
+            (g.getArrow <<< f.getArrow)(i)
+                ==
+            Function1LazyComposition(f.getArrow).andThen(Function1LazyComposition(g.getArrow)).run(i)
+        }
+    }
+
+    func testStackSafety() {
+        let iterations = 200000
+        let sum: Function1LazyComposition<Int, Int> = Function1LazyComposition({ $0 + 1 })
+        let f = Function1LazyComposition.combineAll(sum, Array(repeating: sum, count: iterations - 1))
+
+        XCTAssertEqual(f.run(0), iterations)
+    }
+}


### PR DESCRIPTION
Currently Coyoneda uses function to join the inner function with a function we map over. The problem with this is that if you try to evaluate[1] a coyoneda value that has been mapped a lot of times you get a stack overflow.

This PR solves this issue by using a new `Function1LazyComposition` that keeps a type-erase list of functions that can be called one after the other.

This solution is similar to how Coyoneda was implemented in Bow before, and also how it is implemented in [Scala](https://github.com/typelevel/cats/blob/master/free/src/main/scala/cats/free/Coyoneda.scala), but `Function1LazyComposition` keeps track of what the input and output types of the composed function are.


[1] For example when calling `lower()` or `flatMap`